### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/bin/doi2bibtex
+++ b/bin/doi2bibtex
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-bibtex=$(curl -LH "Accept: text/bibliography; style=bibtex" http://dx.doi.org/"$1") 
+bibtex=$(curl -LH "Accept: text/bibliography; style=bibtex" https://doi.org/"$1") 
 
 bibtex=$(echo "$bibtex" | sed -re "s/[^ ]+/&\n/" | sed -e "s/},/&\n/g")
 


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates the code that generates new DOI links.

Cheers!